### PR TITLE
Add details about possible race condition when fixing expired certificate

### DIFF
--- a/Scripts/FixExpiredCert-AEPCC.ps1
+++ b/Scripts/FixExpiredCert-AEPCC.ps1
@@ -167,6 +167,12 @@ function fixNodes
                     #>
                     function StopServiceFabricServices
                     {
+                        if ($(Get-Process | ? ProcessName -like "*FabricInstaller*" | measure).Count -gt 0) {
+                            Write-Warning "Found FabricInstaller running, may cause issues if not stopped, consult manual guide..."
+                            Write-Host "Pausing (15s)..."
+                            Start-Service -Seconds 15
+                        }
+
                         $bootstrapAgent = "ServiceFabricNodeBootstrapAgent"
                         $fabricHost = "FabricHostSvc"
 

--- a/Scripts/FixExpiredCert.ps1
+++ b/Scripts/FixExpiredCert.ps1
@@ -52,6 +52,12 @@ ForEach($nodeIpAddress in $nodeIpArray)
 
         function StopServiceFabricServices
         {
+            if ($(Get-Process | ? ProcessName -like "*FabricInstaller*" | measure).Count -gt 0) {
+                Write-Warning "Found FabricInstaller running, may cause issues if not stopped, consult manual guide..."
+                Write-Host "Pausing (15s)..."
+                Start-Service -Seconds 15
+            }
+
             $bootstrapAgent = "ServiceFabricNodeBootstrapAgent"
             $fabricHost = "FabricHostSvc"
 

--- a/Security/Fix Expired Cluster Certificate Manual Steps.md
+++ b/Security/Fix Expired Cluster Certificate Manual Steps.md
@@ -124,15 +124,22 @@ Service Fabric clusters running 6.5 CU3 or later (version 6.5.658.9590 or higher
 
     * If RDP to each node is not feasible, alternatively you can automate through [Desired State Configuration](https://docs.microsoft.com/en-us/powershell/dsc/azuredsc "https://docs.microsoft.com/en-us/powershell/dsc/azuredsc")
 
- 
+
 
 8. Stop both "Azure Service Fabric Node Bootstrap Agent" and "Microsoft Service Fabric Host Service" service (run in this exact order) 
 
-    * net stop ServiceFabricNodeBootstrapAgent 
+    * net stop ServiceFabricNodeBootstrapAgent
 
-    * net stop FabricHostSvc 
+    * net stop FabricHostSvc
 
-  
+There is a race condition where sometimes `FabricInstallerService.exe` is stuck in a crashing loop. If this is the case first launch `Services.msc` and identify 3 Services:
+
+- FabricInstallerService
+- FabricHostService
+- ServiceFabricNodeBootstrapAgent
+
+Then, set all services to startup type `Disabled`, and reboot the machine. On reboot `FabricInstallerService.exe` should never run. Continue along with the TSG.
+
 
 9. Locate ClusterManifest.current in the SvcFab folder like "D:\SvcFab\_sys_0\Fabric\ClusterManifest.current.xml" according to actual datapath deployed, and copy to somewhere like D:\Temp\clusterManifest.xml 
 
@@ -172,7 +179,14 @@ Service Fabric clusters running 6.5 CU3 or later (version 6.5.658.9590 or higher
     net start FabricHostSvc 
     net start ServiceFabricNodeBootstrapAgent 
     ```
- 
+
+If you previously encountered a race condition where `FabricInstallerService.exe` was crashing you can use `Services.msc` to reset the following services to these startup types. Be sure to set:
+
+- FabricInstallerService -> Manual
+- FabricHostService -> Automatic
+- ServiceFabricNodeBootstrapAgent -> Automatic
+
+
 
 13. Open Task Manager and wait for a couple minutes to verify that **FabricGateway.exe** is running 
 


### PR DESCRIPTION
This change adds a check to see if "FabricInstaller.exe" is running at some point while updating an expired cluster certificate. 

A possible race condition can occur that would cause the Fabric Installer to crash and restart indefinitely. Instructions added in this case to attempt a manual mitigation and restart of all services. Added a check to the powershell scripts that will emit a warning.