### PR TITLE
modify Scripts/FixExpiredCert*.ps1 scripts add -localOnly switch add registry fallback values

### DIFF
--- a/Deployment/Example ASP.Net Core Kestrel Https Windows Container.md
+++ b/Deployment/Example ASP.Net Core Kestrel Https Windows Container.md
@@ -297,8 +297,6 @@ Virtual Machine Images - List Skus: https://docs.microsoft.com/en-us/rest/api/co
 
 ### RDP to node  
 
-Additional information on how to connect to cluster is available here [Remote connect to a virtual machine scale set instance or a cluster node](https://docs.microsoft.com/azure/service-fabric/service-fabric-cluster-remote-connect-to-azure-cluster-node)
-
 1. Start 'Remote Desktop Connection' (mstsc.exe)  
 1. in 'Computer' field, enter the cluster FQDN and port number.  
     **NOTE: Azure service fabric clusters provision incrementing NAT rules to each node for RDP access starting at port 3389.**  

--- a/Deployment/Example ASP.Net Core Kestrel Https Windows Container.md
+++ b/Deployment/Example ASP.Net Core Kestrel Https Windows Container.md
@@ -297,6 +297,8 @@ Virtual Machine Images - List Skus: https://docs.microsoft.com/en-us/rest/api/co
 
 ### RDP to node  
 
+Additional information on how to connect to cluster is available here [Remote connect to a virtual machine scale set instance or a cluster node](https://docs.microsoft.com/azure/service-fabric/service-fabric-cluster-remote-connect-to-azure-cluster-node)
+
 1. Start 'Remote Desktop Connection' (mstsc.exe)  
 1. in 'Computer' field, enter the cluster FQDN and port number.  
     **NOTE: Azure service fabric clusters provision incrementing NAT rules to each node for RDP access starting at port 3389.**  

--- a/Scripts/FixExpiredCert-AEPCC.ps1
+++ b/Scripts/FixExpiredCert-AEPCC.ps1
@@ -81,15 +81,6 @@ If (!(Test-Path $clusterDataRootPath)) {
 #Saving current list of Trusted Hosts
 $curValue = (get-item wsman:\localhost\Client\TrustedHosts).value
 
-if (!$global:creds) {
-    Write-Host "Enter your RDP Credentials"
-    $creds = Get-Credential
-
-    if ($cacheCredentials) {
-        $global:creds = $creds
-    }
-}
-
 $scriptBlock = { 
     param($clusterDataRootPath, $tempPath)
     <#
@@ -331,6 +322,15 @@ if ($localOnly) {
     write-host "executing on local node only"
     invoke-command -ScriptBlock $scriptBlock -ArgumentList $clusterDataRootPath, $tempPath
     return
+}
+
+if (!$global:creds) {
+    Write-Host "Enter your RDP Credentials"
+    $creds = Get-Credential
+
+    if ($cacheCredentials) {
+        $global:creds = $creds
+    }
 }
 
 function fixNodes($title, $scriptBlock, $nodeIpArray) {

--- a/Scripts/FixExpiredCert-AEPCC.ps1
+++ b/Scripts/FixExpiredCert-AEPCC.ps1
@@ -34,11 +34,9 @@
 #>
 
 Param(
-    [Parameter(Mandatory = $false)]
     [ValidateNotNullOrEmpty()]
     [string[]] $nodeIpArray = @("0"),
     [string]$clusterDataRootPath = 'd:\svcfab',
-    [Parameter(Mandatory = $false)]
     [ValidateNotNullOrEmpty()]
     [string]$tempPath = 'd:\temp\certwork',
     [switch]$cacheCredentials,

--- a/Scripts/FixExpiredCert-AEPCC.ps1
+++ b/Scripts/FixExpiredCert-AEPCC.ps1
@@ -7,7 +7,7 @@
 
 <#
  .SYNOPSIS
-    Fix the Service Fabric Cluster with Expired Certificate (Self Signed
+    Fix the Service Fabric Cluster with Expired Certificate (Self Signed only)
 
  .DESCRIPTION
     Script can be used to recover the Service Fabric cluster with expired certificate. 
@@ -15,394 +15,421 @@
  .PARAMETER nodeIpArray
     By default script will automatically grab the IP address for all the nodes
 
+ .PARAMETER clusterDataRootPath
+    Cluster data root path. default 'd:\svcfab'
+
  .PARAMETER tempPath
     A temporary working folder to copy and work with Cluster Manifest and Settings files
 
  .PARAMETER cacheCredentials
     switch to optionally enable storing credentials in $global:creds variable.
     to clear, execute: $global:creds=$null
+
+.PARAMETER localOnly
+    switch to optionally run script only on local node.
+    use when there are connectivity issues between nodes by rdp'ing to each node and running with this switch.
+
+.LINK
+    iwr https://raw.githubusercontent.com/Azure/Service-Fabric-Troubleshooting-Guides/master/Scripts/FixExpiredCert-AEPCC.ps1 -out $pwd/FixExpiredCert-AEPCC.ps1
 #>
+
 Param(
-    [Parameter(Mandatory = $false)] #$true
+    [Parameter(Mandatory = $false)]
     [ValidateNotNullOrEmpty()]
     [string[]] $nodeIpArray = @("0"),
-
-    [Parameter(Mandatory = $false)] #$true
+    [string]$clusterDataRootPath = 'd:\svcfab',
+    [Parameter(Mandatory = $false)]
     [ValidateNotNullOrEmpty()]
-    [string]$tempPath = "d:\temp\certwork", 
-
-    [Parameter(Mandatory = $false)] 
-    [switch]$cacheCredentials
+    [string]$tempPath = 'd:\temp\certwork',
+    [switch]$cacheCredentials,
+    [switch]$localOnly
 )
 
 $ErrorActionPreference = 'continue'
+$supportedVersion = [version]"6.5.658.9590"
+$currentVersion = [version]"0.0"
 $startTime = get-date
 $global:failNodes = @()
 $global:successNodes = @()
-
-<#
-.SYNOPSIS
-    Get the SF Cluster Data Root from Registry    
-#>
 $SFEnv = Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Service Fabric" 
-$clusterDataRootPath = $SFEnv.FabricDataRoot
-$supportedVersion = [version]"6.5.658.9590"
- 
+$defaultBinary = 'C:\Program Files\Microsoft Service Fabric\bin\FabricHost.exe'
+
+if ($SFEnv.FabricDataRoot) {
+    $clusterDataRootPath = $SFEnv.FabricDataRoot
+}
+
+if ($SFEnv.FabricVersion) {
+    $currentVersion = $SFEnv.FabricVersion
+}
+else {
+    $currentVersion = [io.fileinfo]::new($defaultBinary).VersionInfo.FileVersion
+}
+
 #Verifying whether SF Runtime is un supported version for AEPCC parameter 
-if ([version]$SFEnv.FabricVersion -gt $supportedVersion ) {
+if ($currentVersion -lt $supportedVersion ) {
+    write-warning "This Script is supported for the Service Fabric runtime version greater than $supportedVersion. 
+        Please leverage external TSG 
+        'https://github.com/Azure/Service-Fabric-Troubleshooting-Guides/blob/master/Security/Fix%20Expired%20Cluster%20Certificate%20Automated%20Script.md' 
+        for fixing the issue with : $($SFEnv.FabricVersion )"
+    return
+}
 
-    If (!(Test-Path $clusterDataRootPath)) {
-        Write-Host $clusterDataRootPath " not found, exiting."
-        Exit-PSSession
+If (!(Test-Path $clusterDataRootPath)) {
+    write-warning $clusterDataRootPath " not found, exiting."
+    return
+}
+
+#Saving current list of Trusted Hosts
+$curValue = (get-item wsman:\localhost\Client\TrustedHosts).value
+
+if (!$global:creds) {
+    Write-Host "Enter your RDP Credentials"
+    $creds = Get-Credential
+
+    if ($cacheCredentials) {
+        $global:creds = $creds
     }
+}
 
-    #Saving current list of Trusted Hosts
-    $curValue = (get-item wsman:\localhost\Client\TrustedHosts).value
-
-    if (!$global:creds) {
-        Write-Host "Enter your RDP Credentials"
-
-        #Get the RDP User Name and Password
-        $creds = Get-Credential
-
-        if ($cacheCredentials) {
-            $global:creds = $creds
+$scriptBlock = { 
+    param($clusterDataRootPath, $tempPath)
+    <#
+        .SYNOPSIS
+        . Updating Cluster Manifest file with AEPCC Parameter  
+        #>
+    function updateManifest {            
+        Write-Host "$env:computername : Begin updating ClusterManifest.xml File"
+        $manFile = $tempPath + "\clustermanifest.current.xml"
+        $newManifest = $tempPath + "\modified_clustermanifest.xml"
+        #Checking the AEPCC property value        
+        [object]$tempManAEPCC = get-content $manFile | select-string -pattern '<Parameter Name="AcceptExpiredPinnedClusterCertificate" Value="false" />' -AllMatches
+        
+        if ($tempManAEPCC) {
+            Write-Host "$env:computername : AEPCC is False"
+            $intermediateManifest = $tempPath + "\intermediate_clustermanifest.xml"
+            get-content $manFile | ? { $_.trim() -ne '<Parameter Name="AcceptExpiredPinnedClusterCertificate" Value="false" />' } | set-content $intermediateManifest 
+            $manFile = $intermediateManifest
         }
-    }
-
-    function fixNodes($title) {
-        $count = 0
-
-        ForEach ($nodeIpAddress in $nodeIpArray) {
-            $count++
-            #Verifying whether corresponding VM is up and running
-            if (Test-Connection -ComputerName $nodeIpAddress -Quiet) {
-                $activity = "$title : total minutes: $(((get-date) - $startTime).TotalMinutes.tostring("0.0")). connecting to: $nodeIpAddress  ($count of $($nodeIpArray.Count))"
-                $status = "success: $($global:successNodes | sort -Unique) fail: $($global:failNodes | sort -Unique)"
-                Write-Progress -Activity $activity `
-                    -Status $status `
-                    -PercentComplete (($count / $nodeIpArray.Count) * 100)
-                write-host "updating trustedhosts list" -foregroundcolor green
-                set-item wsman:\localhost\Client\TrustedHosts -value $nodeIpAddress -Force   
-                Write-Host "---------------------------------------------------------------------------------------------------------"
-                Write-Host "---- Node IP    :" $nodeIpAddress
-                
-                Start-Sleep(1)
-
-                $error.clear()
-                Invoke-Command -Authentication Negotiate -ComputerName $nodeIpAddress {
-                    $temp = Set-NetFirewallRule -DisplayGroup  'File and Printer Sharing' -Enabled True -PassThru |
-                    Select-Object DisplayName, Enabled
-                } -Credential ($creds)
-
-                if ($error) {
-                    $global:failNodes += $nodeIpAddress
-                    continue
-                }
-
-                #******************************************************************************
-                # Script body
-                # Execution begins here
-                #******************************************************************************
-                
-                $error.clear()
-                Invoke-Command -Authentication Negotiate -Computername $nodeIpAddress -Scriptblock { param($clusterDataRootPath, $tempPath)
-                    <#
-                    .SYNOPSIS
-                    . Updating Cluster Manifest file with AEPCC Parameter  
-                    #>
-                    function updateManifest {            
-                        Write-Host "$env:computername : Begin updating ClusterManifest.xml File"
-                        $manFile = $tempPath + "\clustermanifest.current.xml"
-                        $newManifest = $tempPath + "\modified_clustermanifest.xml"
-                        #Checking the AEPCC property value        
-                        [object]$tempManAEPCC = get-content $manFile | select-string -pattern '<Parameter Name="AcceptExpiredPinnedClusterCertificate" Value="false" />' -AllMatches
-                    
-                        if ($tempManAEPCC) {
-                            Write-Host "$env:computername : AEPCC is False"
-                            $intermediateManifest = $tempPath + "\intermediate_clustermanifest.xml"
-                            get-content $manFile | ? { $_.trim() -ne '<Parameter Name="AcceptExpiredPinnedClusterCertificate" Value="false" />' } | set-content $intermediateManifest 
-                            $manFile = $intermediateManifest
-                        }
-                    
-                        $ModContent = Get-Content -Path $manFile |
-                        ForEach-Object {
-                            # Output the existing line to pipeline in any case
-                            $_
-                        
-                            if ($_ -match '<Section Name="Security">' ) {
-                                '      <Parameter Name="AcceptExpiredPinnedClusterCertificate" Value="true" />'
-                            }
-                        }
+        
+        $ModContent = Get-Content -Path $manFile |
+        ForEach-Object {
+            # Output the existing line to pipeline in any case
+            $_
             
-                        $ModContent | Out-File -FilePath $newManifest -Encoding Default -Force  
-                            
-                        Write-Host "$env:computername : Updated the ClusterManifest.xml File : $newManifest"
-                    
-                    }
-                    <#
-                    .SYNOPSIS
-                    . Updating Cluster Setting file with AEPCC Parameter  
-                    #>
-
-                    function updateSettings {       
-                        Write-Host "$env:computername : Begin updating Settings.xml File"
-                        $settingFile = $tempPath + "\Settings.xml"
-                        $newSettings = $tempPath + "\modified_settings.xml"
-
-                        #Checking the AEPCC property value 
-
-                        [object]$tempSettingAEPCC = get-content $settingFile | select-string -pattern '<Parameter Name="AcceptExpiredPinnedClusterCertificate" Value="false" />' -AllMatches
-                        if ($tempSettingAEPCC) {
-                            Write-Host "$env:computername : AEPCC is False"
-                            $intermediateSettings = $tempPath + "\intermediate_Settings.xml"
-                            get-content $settingFile | ? { $_.trim() -ne '<Parameter Name="AcceptExpiredPinnedClusterCertificate" Value="false" />' } | set-content $intermediateSettings 
-                            $settingFile = $intermediateSettings
-                        }                   
-                    
-                        $ModContent = Get-Content -Path $settingFile |
-                        ForEach-Object {             
-                            $_
-                
-                            if ($_ -match '<Section Name="Security">' ) {
-                                '    <Parameter Name="AcceptExpiredPinnedClusterCertificate" Value="true" />'
-                            }
-                        }
-                    
-                        $ModContent | Out-File -FilePath $newSettings -Encoding Default -Force
-                        Write-Host "$env:computername : Updated Settings.xml $newSettings"
-                    }
-
-                    <#
-                    .SYNOPSIS
-                    . Stopping both SFNBA and FabricHost
-                    #>
-                    function StopServiceFabricServices {
-                        if ($(Get-Process | ? ProcessName -like "*FabricInstaller*" | measure).Count -gt 0) {
-                            Write-Warning "$env:computername : Found FabricInstaller running, may cause issues if not stopped, consult manual guide..."
-                            Write-Host "$env:computername : Pausing (15s)..."
-                            Start-Sleep -Seconds 15
-                        }
-
-                        $bootstrapAgent = "ServiceFabricNodeBootstrapAgent"
-                        $fabricHost = "FabricHostSvc"
-
-                        $bootstrapService = Get-Service -Name $bootstrapAgent
-                        if ($bootstrapService.Status -eq "Running") {
-                            Stop-Service $bootstrapAgent -ErrorAction SilentlyContinue
-                            Write-Host "$env:computername : Stopping $bootstrapAgent service" 
-                        }
-                        Do {
-                            Start-Sleep -Seconds 1
-                            $bootstrapService = Get-Service -Name $bootstrapAgent
-                            if ($bootstrapService.Status -eq "Stopped") {
-                                Write-Host "$env:computername : $bootstrapAgent now stopped" 
-                            }
-                            else {
-                                Write-Host "$env:computername : $bootstrapAgent current status: $($bootstrapService.Status)"
-                            }
-
-                        } While ($bootstrapService.Status -ne "Stopped")
-
-                        $fabricHostService = Get-Service -Name $fabricHost
-                        if ($fabricHostService.Status -eq "Running") {
-                            Stop-Service $fabricHost -ErrorAction SilentlyContinue
-                            Write-Host "$env:computername : Stopping $fabricHost service" 
-                        }
-                        Do {
-                            Start-Sleep -Seconds 1
-                            $fabricHostService = Get-Service -Name $fabricHost
-                            if ($fabricHostService.Status -eq "Stopped") {
-                                Write-Host "$env:computername : $fabricHost now stopped" 
-                            }
-                            else {
-                                Write-Host "$env:computername : $fabricHost current status: $($fabricHostService.Status)"
-                            }
-
-                        } While ($fabricHostService.Status -ne "Stopped")
-                    }
-
-                    <#
-                    .SYNOPSIS
-                    . Starting both SFNBA and FabricHost
-                    #>
-                    function StartServiceFabricServices {
-                        $bootstrapAgent = "ServiceFabricNodeBootstrapAgent"
-                        $fabricHost = "FabricHostSvc"
-
-                        $fabricHostService = Get-Service -Name $fabricHost
-                        if ($fabricHostService.Status -eq "Stopped") {
-                            Start-Service $fabricHost -ErrorAction SilentlyContinue
-                            Write-Host "$env:computername : Starting $fabricHost service" 
-                        }
-                        Do {
-                            Start-Sleep -Seconds 1
-                            $fabricHostService = Get-Service -Name $fabricHost
-                            if ($fabricHostService.Status -eq "Running") {
-                                Write-Host "$env:computername : $fabricHost now running" 
-                            }
-                            else {
-                                Write-Host "$env:computername : $fabricHost current status: $($fabricHostService.Status)"
-                            }
-
-                        } While ($fabricHostService.Status -ne "Running")
-
-                        $bootstrapService = Get-Service -Name $bootstrapAgent
-                        if ($bootstrapService.Status -eq "Stopped") {
-                            Start-Service $bootstrapAgent -ErrorAction SilentlyContinue
-                            Write-Host "$env:computername : Starting $bootstrapAgent service" 
-                        }
-
-                        do {
-                            Start-Sleep -Seconds 1
-                            $bootstrapService = Get-Service -Name $bootstrapAgent
-                            if ($bootstrapService.Status -eq "Running") {
-                                Write-Host "$env:computername : $bootstrapAgent now running" 
-                            }
-                            else {
-                                Write-Host "$env:computername : $bootstrapAgent current status: $($bootstrapService.Status)"
-                            }
-
-                        } While ($bootstrapService.Status -ne "Running")
-                    }
-
-                    #config files we need
-                    #"D:\SvcFab\ClusterManifest.current.xml"
-                    #"D:\SvcFab\<<node name>>\Fabric\Fabric.Config.<highest version> \Settings.xml"
-
-                    $result = Get-ChildItem -Path $clusterDataRootPath -Filter "Fabric.Data" -Directory -Recurse
-                    $hostPath = $result.Parent.Parent.Name 
-                    
-                    Write-Host "---- Node Name  :  " $hostPath 
-                    Write-Host "---------------------------------------------------------------------------------------------------------"
-
-                    $manifestPath = $clusterDataRootPath + "\" + $hostPath + "\Fabric\ClusterManifest.current.xml"
-                    $infrastructureManifest = $clusterDataRootPath + "\" + $hostPath + "\Fabric\Fabric.Data\InfrastructureManifest.xml"
-                    
-                    # Validating whether Manifest file already contain AEPCC parameter with true                   
-                    [object]$tempAEPCC = get-content $manifestPath | select-string -pattern '<Parameter Name="AcceptExpiredPinnedClusterCertificate" Value="true" />' -AllMatches
-                            
-                    If (!$tempAEPCC) {
-                        #to get the settings.xml we need to determine the current version
-                        #"D:\SvcFab\<node name>\Fabric\Fabric.Package.current.xml" --> Read to determine version# <ConfigPackage Name="Fabric.Config" Version="1.131523081591497214" />
-                        $currentPackage = $clusterDataRootPath + "\" + $hostPath + "\Fabric\Fabric.Package.current.xml"
-                        $currentPackageXml = [xml](Get-Content $currentPackage)
-                        $packageName = $currentPackageXml.ServicePackage.DigestedConfigPackage.ConfigPackage | Select-Object -ExpandProperty Name
-                        $packageVersion = $currentPackageXml.ServicePackage.DigestedConfigPackage.ConfigPackage | Select-Object -ExpandProperty Version
-                        $SettingsFile = $clusterDataRootPath + "\" + $hostPath + "\Fabric\" + $packageName + "." + $packageVersion + "\settings.xml"
-                        $SettingsPath = $clusterDataRootPath + "\" + $hostPath + "\Fabric\" + $packageName + "." + $packageVersion
-                        Write-Host "$env:computername : Settings file: " $SettingsFile
-                        Write-Host "$env:computername : Settings path: " $SettingsPath
-
-                        # create a temp folder
-                        $tempFolder = New-Item -ItemType Directory -Force -Path $tempPath 
-
-                        Write-Host "$env:computername : Created the temp Work folder :" $tempFolder
-
-                        #copy current config to the temp folder
-                        Copy-Item -Path $manifestPath -Destination $tempPath -Force -Verbose
-                        $newManifest = $tempPath + "\modified_clustermanifest.xml"
-                        Copy-Item -Path $SettingsFile -Destination $tempPath -Force -Verbose
-                        $newSettings = $tempPath + "\modified_settings.xml"            
-
-                        # Appending cluster manifest File with AcceptExpiredPinnedClusterCertificate with value true
-                        updateManifest
-
-                        # Appending cluster Settings File with AcceptExpiredPinnedClusterCertificate with value true
-                        updateSettings
-
-                        ### Backup.... 
-                        $backupSettingsFile = $SettingsPath + "\settings_backup.xml"
-                        Copy-Item -Path $SettingsFile -Destination $backupSettingsFile -Force -Verbose
-                        Copy-Item -Path $newSettings -Destination $SettingsFile -Force -Verbose
-
-                        #stop these services
-                        Write-Host "$env:computername : Stopping services"
-                        StopServiceFabricServices
-
-                        #update the node configuration
-                        $logRoot = $clusterDataRootPath + "\Log"
-                        Write-Host "$env:computername : Updating Node configuration with new setting AcceptExpiredPinnedClusterCertificate " 
-                    
-                        #For Debugging 
-                        Write-Host "$env:computername : Cluster Manifest $newManifest"
-                        Write-Host "$env:computername : Log Root $logRoot"
-                        Write-Host "$env:computername : Cluster Data Path  : $clusterDataRootPath"
-                        Write-Host "$env:computername : Infra : $infrastructureManifest"
-                    
-                        New-ServiceFabricNodeConfiguration -FabricDataRoot $clusterDataRootPath -FabricLogRoot $logRoot -ClusterManifestPath $newManifest -InfrastructureManifestPath $infrastructureManifest 
-                        Write-Host "$env:computername : Updating Node configuration complete"
-
-                        #restart these services
-                        Write-Host "$env:computername : Starting services "
-                        StartServiceFabricServices
-                    }
-                    else {
-                        Write-Host "$env:computername : Manifest File already contains the AEPCC parameter $nodeIpAddress"
-                    }
-                } -ArgumentList $clusterDataRootPath, $tempPath
-                
-                if ($error) {
-                    $global:failNodes += $nodeIpAddress
-                }
-                else {
-                    $global:successNodes += $nodeIpAddress
-                }
-            }
-            else {
-                Write-Warning "$env:computername : unable to connect to node: $nodeIpAddress"
-                $global:failNodes += $nodeIpAddress
+            if ($_ -match '<Section Name="Security">' ) {
+                '      <Parameter Name="AcceptExpiredPinnedClusterCertificate" Value="true" />'
             }
         }
-        Write-Progress -Completed -Activity "complete"
+
+        $ModContent | Out-File -FilePath $newManifest -Encoding Default -Force  
+                
+        Write-Host "$env:computername : Updated the ClusterManifest.xml File : $newManifest"
+        
+    }
+    <#
+        .SYNOPSIS
+        . Updating Cluster Setting file with AEPCC Parameter  
+        #>
+
+    function updateSettings {       
+        Write-Host "$env:computername : Begin updating Settings.xml File"
+        $settingFile = $tempPath + "\Settings.xml"
+        $newSettings = $tempPath + "\modified_settings.xml"
+
+        #Checking the AEPCC property value 
+
+        [object]$tempSettingAEPCC = get-content $settingFile | select-string -pattern '<Parameter Name="AcceptExpiredPinnedClusterCertificate" Value="false" />' -AllMatches
+        if ($tempSettingAEPCC) {
+            Write-Host "$env:computername : AEPCC is False"
+            $intermediateSettings = $tempPath + "\intermediate_Settings.xml"
+            get-content $settingFile | ? { $_.trim() -ne '<Parameter Name="AcceptExpiredPinnedClusterCertificate" Value="false" />' } | set-content $intermediateSettings 
+            $settingFile = $intermediateSettings
+        }                   
+        
+        $ModContent = Get-Content -Path $settingFile |
+        ForEach-Object {             
+            $_
+    
+            if ($_ -match '<Section Name="Security">' ) {
+                '    <Parameter Name="AcceptExpiredPinnedClusterCertificate" Value="true" />'
+            }
+        }
+        
+        $ModContent | Out-File -FilePath $newSettings -Encoding Default -Force
+        Write-Host "$env:computername : Updated Settings.xml $newSettings"
     }
 
     <#
+        .SYNOPSIS
+        . Stopping both SFNBA and FabricHost
+        #>
+    function StopServiceFabricServices {
+        if ($(Get-Process | ? ProcessName -like "*FabricInstaller*" | measure).Count -gt 0) {
+            Write-Warning "$env:computername : Found FabricInstaller running, may cause issues if not stopped, consult manual guide..."
+            Write-Host "$env:computername : Pausing (15s)..."
+            Start-Sleep -Seconds 15
+        }
+
+        $bootstrapAgent = "ServiceFabricNodeBootstrapAgent"
+        $fabricHost = "FabricHostSvc"
+
+        $bootstrapService = Get-Service -Name $bootstrapAgent
+        if ($bootstrapService.Status -eq "Running") {
+            Stop-Service $bootstrapAgent -ErrorAction SilentlyContinue
+            Write-Host "$env:computername : Stopping $bootstrapAgent service" 
+        }
+        Do {
+            Start-Sleep -Seconds 1
+            $bootstrapService = Get-Service -Name $bootstrapAgent
+            if ($bootstrapService.Status -eq "Stopped") {
+                Write-Host "$env:computername : $bootstrapAgent now stopped" 
+            }
+            else {
+                Write-Host "$env:computername : $bootstrapAgent current status: $($bootstrapService.Status)"
+            }
+
+        } While ($bootstrapService.Status -ne "Stopped")
+
+        $fabricHostService = Get-Service -Name $fabricHost
+        if ($fabricHostService.Status -eq "Running") {
+            Stop-Service $fabricHost -ErrorAction SilentlyContinue
+            Write-Host "$env:computername : Stopping $fabricHost service" 
+        }
+        Do {
+            Start-Sleep -Seconds 1
+            $fabricHostService = Get-Service -Name $fabricHost
+            if ($fabricHostService.Status -eq "Stopped") {
+                Write-Host "$env:computername : $fabricHost now stopped" 
+            }
+            else {
+                Write-Host "$env:computername : $fabricHost current status: $($fabricHostService.Status)"
+            }
+
+        } While ($fabricHostService.Status -ne "Stopped")
+    }
+
+    <#
+        .SYNOPSIS
+        . Starting both SFNBA and FabricHost
+        #>
+    function StartServiceFabricServices {
+        $bootstrapAgent = "ServiceFabricNodeBootstrapAgent"
+        $fabricHost = "FabricHostSvc"
+
+        $fabricHostService = Get-Service -Name $fabricHost
+        if ($fabricHostService.Status -eq "Stopped") {
+            Start-Service $fabricHost -ErrorAction SilentlyContinue
+            Write-Host "$env:computername : Starting $fabricHost service" 
+        }
+        Do {
+            Start-Sleep -Seconds 1
+            $fabricHostService = Get-Service -Name $fabricHost
+            if ($fabricHostService.Status -eq "Running") {
+                Write-Host "$env:computername : $fabricHost now running" 
+            }
+            else {
+                Write-Host "$env:computername : $fabricHost current status: $($fabricHostService.Status)"
+            }
+
+        } While ($fabricHostService.Status -ne "Running")
+
+        $bootstrapService = Get-Service -Name $bootstrapAgent
+        if ($bootstrapService.Status -eq "Stopped") {
+            Start-Service $bootstrapAgent -ErrorAction SilentlyContinue
+            Write-Host "$env:computername : Starting $bootstrapAgent service" 
+        }
+
+        do {
+            Start-Sleep -Seconds 1
+            $bootstrapService = Get-Service -Name $bootstrapAgent
+            if ($bootstrapService.Status -eq "Running") {
+                Write-Host "$env:computername : $bootstrapAgent now running" 
+            }
+            else {
+                Write-Host "$env:computername : $bootstrapAgent current status: $($bootstrapService.Status)"
+            }
+
+        } While ($bootstrapService.Status -ne "Running")
+    }
+
+    #config files we need
+    #"D:\SvcFab\ClusterManifest.current.xml"
+    #"D:\SvcFab\<<node name>>\Fabric\Fabric.Config.<highest version> \Settings.xml"
+
+    $result = Get-ChildItem -Path $clusterDataRootPath -Filter "Fabric.Data" -Directory -Recurse
+    $hostPath = $result.Parent.Parent.Name 
+        
+    Write-Host "---- Node Name  :  " $hostPath 
+    Write-Host "---------------------------------------------------------------------------------------------------------"
+
+    $manifestPath = $clusterDataRootPath + "\" + $hostPath + "\Fabric\ClusterManifest.current.xml"
+    $infrastructureManifest = $clusterDataRootPath + "\" + $hostPath + "\Fabric\Fabric.Data\InfrastructureManifest.xml"
+        
+    # Validating whether Manifest file already contain AEPCC parameter with true                   
+    [object]$tempAEPCC = get-content $manifestPath | select-string -pattern '<Parameter Name="AcceptExpiredPinnedClusterCertificate" Value="true" />' -AllMatches
+                
+    If (!$tempAEPCC) {
+        #to get the settings.xml we need to determine the current version
+        #"D:\SvcFab\<node name>\Fabric\Fabric.Package.current.xml" --> Read to determine version# <ConfigPackage Name="Fabric.Config" Version="1.131523081591497214" />
+        $currentPackage = $clusterDataRootPath + "\" + $hostPath + "\Fabric\Fabric.Package.current.xml"
+        $currentPackageXml = [xml](Get-Content $currentPackage)
+        $packageName = $currentPackageXml.ServicePackage.DigestedConfigPackage.ConfigPackage | Select-Object -ExpandProperty Name
+        $packageVersion = $currentPackageXml.ServicePackage.DigestedConfigPackage.ConfigPackage | Select-Object -ExpandProperty Version
+        $SettingsFile = $clusterDataRootPath + "\" + $hostPath + "\Fabric\" + $packageName + "." + $packageVersion + "\settings.xml"
+        $SettingsPath = $clusterDataRootPath + "\" + $hostPath + "\Fabric\" + $packageName + "." + $packageVersion
+        Write-Host "$env:computername : Settings file: " $SettingsFile
+        Write-Host "$env:computername : Settings path: " $SettingsPath
+
+        # create a temp folder
+        $tempFolder = New-Item -ItemType Directory -Force -Path $tempPath 
+
+        Write-Host "$env:computername : Created the temp Work folder :" $tempFolder
+
+        #copy current config to the temp folder
+        Copy-Item -Path $manifestPath -Destination $tempPath -Force -Verbose
+        $newManifest = $tempPath + "\modified_clustermanifest.xml"
+        Copy-Item -Path $SettingsFile -Destination $tempPath -Force -Verbose
+        $newSettings = $tempPath + "\modified_settings.xml"            
+
+        # Appending cluster manifest File with AcceptExpiredPinnedClusterCertificate with value true
+        updateManifest
+
+        # Appending cluster Settings File with AcceptExpiredPinnedClusterCertificate with value true
+        updateSettings
+
+        ### Backup.... 
+        $backupSettingsFile = $SettingsPath + "\settings_backup.xml"
+        Copy-Item -Path $SettingsFile -Destination $backupSettingsFile -Force -Verbose
+        Copy-Item -Path $newSettings -Destination $SettingsFile -Force -Verbose
+
+        #stop these services
+        Write-Host "$env:computername : Stopping services"
+        StopServiceFabricServices
+
+        #update the node configuration
+        $logRoot = $clusterDataRootPath + "\Log"
+        Write-Host "$env:computername : Updating Node configuration with new setting AcceptExpiredPinnedClusterCertificate " 
+        
+        #For Debugging 
+        Write-Host "$env:computername : Cluster Manifest $newManifest"
+        Write-Host "$env:computername : Log Root $logRoot"
+        Write-Host "$env:computername : Cluster Data Path  : $clusterDataRootPath"
+        Write-Host "$env:computername : Infra : $infrastructureManifest"
+        
+        New-ServiceFabricNodeConfiguration -FabricDataRoot $clusterDataRootPath -FabricLogRoot $logRoot -ClusterManifestPath $newManifest -InfrastructureManifestPath $infrastructureManifest 
+        Write-Host "$env:computername : Updating Node configuration complete"
+
+        #restart these services
+        Write-Host "$env:computername : Starting services "
+        StartServiceFabricServices
+    }
+    else {
+        Write-Host "$env:computername : Manifest File already contains the AEPCC parameter $nodeIpAddress"
+    }
+}
+
+if ($localOnly) {
+    write-host "executing on local node only"
+    invoke-command -ScriptBlock $scriptBlock -ArgumentList $clusterDataRootPath, $tempPath
+    return
+}
+
+function fixNodes($title, $scriptBlock, $nodeIpArray) {
+    $count = 0
+
+    ForEach ($nodeIpAddress in $nodeIpArray) {
+        $count++
+        #Verifying whether corresponding VM is up and running
+        if (Test-Connection -ComputerName $nodeIpAddress -Quiet) {
+            $activity = "$title : total minutes: $(((get-date) - $startTime).TotalMinutes.tostring("0.0")). connecting to: $nodeIpAddress  ($count of $($nodeIpArray.Count))"
+            $status = "success: $($global:successNodes | sort -Unique) fail: $($global:failNodes | sort -Unique)"
+            Write-Progress -Activity $activity `
+                -Status $status `
+                -PercentComplete (($count / $nodeIpArray.Count) * 100)
+            write-host "updating trustedhosts list" -foregroundcolor green
+            set-item wsman:\localhost\Client\TrustedHosts -value $nodeIpAddress -Force   
+            Write-Host "---------------------------------------------------------------------------------------------------------"
+            Write-Host "---- Node IP    :" $nodeIpAddress
+                
+            Start-Sleep(1)
+
+            $error.clear()
+            Invoke-Command -Authentication Negotiate -ComputerName $nodeIpAddress {
+                $temp = Set-NetFirewallRule -DisplayGroup  'File and Printer Sharing' -Enabled True -PassThru |
+                Select-Object DisplayName, Enabled
+            } -Credential ($creds)
+
+            if ($error) {
+                $global:failNodes += $nodeIpAddress
+                continue
+            }
+
+            #******************************************************************************
+            # Script body
+            # Execution begins here
+            #******************************************************************************
+                
+            $error.clear()
+            Invoke-Command -Authentication Negotiate -Computername $nodeIpAddress -Scriptblock $scriptBlock -ArgumentList $clusterDataRootPath, $tempPath
+                
+            if ($error) {
+                $global:failNodes += $nodeIpAddress
+            }
+            else {
+                $global:successNodes += $nodeIpAddress
+            }
+        }
+        else {
+            Write-Warning "$env:computername : unable to connect to node: $nodeIpAddress"
+            $global:failNodes += $nodeIpAddress
+        }
+    }
+    Write-Progress -Completed -Activity "complete"
+}
+
+<#
     .SYNOPSIS
     Get the list of seed nodes
     #>
-    if ($nodeIpArray[0] -eq 0 ) {
-        Write-Host "Getting Seed node details" -foregroundcolor green
-        $result = Get-ChildItem -Path $clusterDataRootPath -Filter "Fabric.Data" -Directory -Recurse
-        $hostPath = $result.Parent.Parent.Name 
-        $manifestPath = $clusterDataRootPath + "\" + $hostPath + "\Fabric\ClusterManifest.current.xml"
-        $manConfig = [System.Xml.XmlDocument](Get-Content $manifestPath)
-        $seedNode = $manConfig.ClusterManifest.Infrastructure.PaaS.Votes.Vote
-        $nodeIpArray = $seedNode.IPAddressOrFQDN
-        fixNodes "Seed Nodes"
-    }
-    else {
-        fixNodes "Custom Nodes"
-    }
-
-    Write-host "Getting the list of all nodes" -foregroundcolor green
-    start-sleep -Seconds 60
-
-    Connect-ServiceFabricCluster
-    $node = Get-ServiceFabricNode
-    $nodeIpArray = $node.IpAddressOrFQDN 
-    Write-host "Fixing All Nodes" -foregroundcolor green
-
-    fixNodes "All Nodes"
-    write-host "reset trusted hosts to original values" -foregroundcolor green
-    set-item wsman:\localhost\Client\TrustedHosts -value $curValue -Force
-    Write-Progress -Completed -Activity "complete"
-
-    if ($global:successNodes) {
-        $successUnique = $global:successNodes | sort-object -Unique
-        write-host "total node success: $(@($successUnique).Count)" -ForegroundColor green
-        write-host ($successUnique | fl * | out-string)
-    }
-    
-    if ($global:failNodes) {
-        $failUnique = $global:failNodes | sort-object -Unique
-        write-warning "`r`ntotal node connection errors: $(@($failUnique).Count). review output"   
-        write-host ($failUnique | fl * | out-string)
-    }
-
-    write-host "finished. total minutes: $(((get-date) - $startTime).TotalMinutes.ToString("0.0"))" -foregroundcolor green
+if ($nodeIpArray[0] -eq 0 ) {
+    Write-Host "Getting Seed node details" -foregroundcolor green
+    $result = Get-ChildItem -Path $clusterDataRootPath -Filter "Fabric.Data" -Directory -Recurse
+    $hostPath = $result.Parent.Parent.Name 
+    $manifestPath = $clusterDataRootPath + "\" + $hostPath + "\Fabric\ClusterManifest.current.xml"
+    $manConfig = [System.Xml.XmlDocument](Get-Content $manifestPath)
+    $seedNode = $manConfig.ClusterManifest.Infrastructure.PaaS.Votes.Vote
+    $nodeIpArray = $seedNode.IPAddressOrFQDN
+    fixNodes -title "Seed Nodes" -scriptBlock $scriptBlock -nodeIpArray $nodeIpArray
 }
 else {
-    write-warning "This Script is supported for the Service Fabric runtime version greater than $supportedVersion. 
-    Please leverage external TSG 'https://github.com/Azure/Service-Fabric-Troubleshooting-Guides/blob/master/Security/Fix%20Expired%20Cluster%20Certificate%20Automated%20Script.md' for fixing the issue with : $($SFEnv.FabricVersion )"
+    fixNodes -title "Custom Nodes" -scriptBlock $scriptBlock -nodeIpArray $nodeIpArray
 }
+
+Write-host "Getting the list of all nodes" -foregroundcolor green
+start-sleep -Seconds 60
+
+Connect-ServiceFabricCluster
+$node = Get-ServiceFabricNode
+$nodeIpArray = $node.IpAddressOrFQDN 
+Write-host "Fixing All Nodes" -foregroundcolor green
+
+fixNodes -title "All Nodes" -scriptBlock $scriptBlock -nodeIpArray $nodeIpArray
+write-host "reset trusted hosts to original values" -foregroundcolor green
+set-item wsman:\localhost\Client\TrustedHosts -value $curValue -Force
+Write-Progress -Completed -Activity "complete"
+
+if ($global:successNodes) {
+    $successUnique = $global:successNodes | sort-object -Unique
+    write-host "total node success: $(@($successUnique).Count)" -ForegroundColor green
+    write-host ($successUnique | fl * | out-string)
+}
+    
+if ($global:failNodes) {
+    $failUnique = $global:failNodes | sort-object -Unique
+    write-warning "`r`ntotal node connection errors: $(@($failUnique).Count). review output"   
+    write-host ($failUnique | fl * | out-string)
+    write-warning "for any failed nodes, rdp to node and run this script with '-localOnly' switch"
+}
+
+write-host "finished. total minutes: $(((get-date) - $startTime).TotalMinutes.ToString("0.0"))" -foregroundcolor green
+

--- a/Scripts/FixExpiredCert-AEPCC.ps1
+++ b/Scripts/FixExpiredCert-AEPCC.ps1
@@ -53,6 +53,7 @@ $global:failNodes = @()
 $global:successNodes = @()
 $SFEnv = Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Service Fabric" 
 $defaultBinary = 'C:\Program Files\Microsoft Service Fabric\bin\FabricHost.exe'
+$creds = $null
 
 if ($SFEnv.FabricDataRoot) {
     $clusterDataRootPath = $SFEnv.FabricDataRoot

--- a/Scripts/FixExpiredCert.ps1
+++ b/Scripts/FixExpiredCert.ps1
@@ -25,30 +25,27 @@
     [switch] enable storing credentials in $global:creds variable.
     to clear, execute: $global:creds=$null
 
+.PARAMETER localOnly
+    switch to optionally run script only on local node.
+    use when there are connectivity issues between nodes by rdp'ing to each node and running with this switch.
+
+.LINK
+    iwr https://raw.githubusercontent.com/Azure/Service-Fabric-Troubleshooting-Guides/master/Scripts/FixExpiredCert.ps1 -out $pwd/FixExpiredCert.ps1
 #>
+
 Param(
-    [Parameter(Mandatory = $false)]
     [ValidateNotNullOrEmpty()]
     [string] $clusterDataRootPath = "D:\SvcFab",
-
-    [Parameter(Mandatory = $false)]
     [ValidateNotNullOrEmpty()]
     [string]$oldThumbprint = "replace with expired thumbprint",
-
-    [Parameter(Mandatory = $false)]
     [ValidateNotNullOrEmpty()]
     [string]$newThumbprint = "replace with new thumbprint",
-
-    [Parameter(Mandatory = $false)]
     [ValidateNotNullOrEmpty()]
     [string]$certStoreLocation = 'Cert:\LocalMachine\My\',
-
-    [Parameter(Mandatory = $false)]
     [ValidateNotNullOrEmpty()]
     [string[]]$nodeIpArray = @("10.0.0.4", "10.0.0.5", "10.0.0.6" ),
-
-    [Parameter(Mandatory = $false)] 
-    [switch]$cacheCredentials
+    [switch]$cacheCredentials,
+    [switch]$localOnly
 )
 
 $error.Clear()
@@ -57,6 +54,7 @@ $startTime = get-date
 $global:failNodes = @()
 $global:successNodes = @()
 $count = 0
+$creds = $null
 
 If (!(Test-Path $clusterDataRootPath)) {
     Write-Host $clusterDataRootPath " not found, exiting."
@@ -79,6 +77,218 @@ if (!$global:creds) {
 if (![regex]::IsMatch($oldThumbprint, '^[0-9A-Fa-f]{24,}$') -or ![regex]::IsMatch($newThumbprint, '^[0-9A-Fa-f]{24,}$')) {
     write-warning "verify oldthumbprint:($oldthumbprint) and newthumbprint:($newthumbprint) are specified and are correct."
     #return
+}
+
+$scriptBlock = { param($clusterDataRootPath, $oldThumbprint, $newThumbprint, $certStoreLocation)
+    Write-Host "$env:computername : Running on $((Get-WmiObject win32_computersystem).DNSHostName)" -ForegroundColor Green
+
+    function StopServiceFabricServices {
+        if ($(Get-Process | ? ProcessName -like "*FabricInstaller*" | measure).Count -gt 0) {
+            Write-Warning "$env:computername : Found FabricInstaller running, may cause issues if not stopped, consult manual guide..."
+            Write-Host "$env:computername : Pausing (15s)..." -ForegroundColor Green
+            Start-Sleep -Seconds 15
+        }
+
+        $bootstrapAgent = "ServiceFabricNodeBootstrapAgent"
+        $fabricHost = "FabricHostSvc"
+
+        $bootstrapService = Get-Service -Name $bootstrapAgent
+        if ($bootstrapService.Status -eq "Running") {
+            Stop-Service $bootstrapAgent -ErrorAction SilentlyContinue 
+            Write-Host "$env:computername : Stopping $bootstrapAgent service" -ForegroundColor Green
+        }
+        Do {
+            Start-Sleep -Seconds 1
+            $bootstrapService = Get-Service -Name $bootstrapAgent
+            if ($bootstrapService.Status -eq "Stopped") {
+                Write-Host "$env:computername : $bootstrapAgent now stopped" -ForegroundColor Green
+            }
+            else {
+                Write-Host "$env:computername : $bootstrapAgent current status: $($bootstrapService.Status)" -ForegroundColor Green
+            }
+
+        } While ($bootstrapService.Status -ne "Stopped")
+
+        $fabricHostService = Get-Service -Name $fabricHost
+        if ($fabricHostService.Status -eq "Running") {
+            Stop-Service $fabricHost -ErrorAction SilentlyContinue 
+            Write-Host "$env:computername : Stopping $fabricHost service" -ForegroundColor Green
+        }
+        Do {
+            Start-Sleep -Seconds 1
+            $fabricHostService = Get-Service -Name $fabricHost
+            if ($fabricHostService.Status -eq "Stopped") {
+                Write-Host "$env:computername : $fabricHost now stopped" -ForegroundColor Green
+            }
+            else {
+                Write-Host "$env:computername : $fabricHost current status: $($fabricHostService.Status)" -ForegroundColor Green
+            }
+
+        } While ($fabricHostService.Status -ne "Stopped")
+    }
+
+    function StartServiceFabricServices {
+        $bootstrapAgent = "ServiceFabricNodeBootstrapAgent"
+        $fabricHost = "FabricHostSvc"
+
+        $fabricHostService = Get-Service -Name $fabricHost
+        if ($fabricHostService.Status -eq "Stopped") {
+            Start-Service $fabricHost -ErrorAction SilentlyContinue 
+            Write-Host "$env:computername : Starting $fabricHost service" -ForegroundColor Green
+        }
+        Do {
+            Start-Sleep -Seconds 1
+            $fabricHostService = Get-Service -Name $fabricHost
+            if ($fabricHostService.Status -eq "Running") {
+                Write-Host "$env:computername : $fabricHost now running" -ForegroundColor Green
+            }
+            else {
+                Write-Host "$env:computername : $fabricHost current status: $($fabricHostService.Status)" -ForegroundColor Green
+            }
+
+        } While ($fabricHostService.Status -ne "Running")
+
+
+        $bootstrapService = Get-Service -Name $bootstrapAgent
+        if ($bootstrapService.Status -eq "Stopped") {
+            Start-Service $bootstrapAgent -ErrorAction SilentlyContinue 
+            Write-Host "$env:computername : Starting $bootstrapAgent service" -ForegroundColor Green
+        }
+        Do {
+            Start-Sleep -Seconds 1
+            $bootstrapService = Get-Service -Name $bootstrapAgent
+            if ($bootstrapService.Status -eq "Running") {
+                Write-Host "$env:computername : $bootstrapAgent now running" -ForegroundColor Green
+            }
+            else {
+                Write-Host "$env:computername : $bootstrapAgent current status: $($bootstrapService.Status)" -ForegroundColor Green
+            }
+
+        } While ($bootstrapService.Status -ne "Running")
+    }
+
+    #config files we need
+    #"D:\SvcFab\clusterManifest.xml"
+    #"D:\SvcFab\_sys_0\Fabric\Fabric.Data\InfrastructureManifest.xml"
+    #"D:\SvcFab\_sys_0\Fabric\Fabric.Config.1.131523081591497214\Settings.xml"
+
+    $result = Get-ChildItem -Path $clusterDataRootPath -Filter "Fabric.Data" -Directory -Recurse
+    $hostPath = $result.Parent.Parent.Name
+    Write-Host "---------------------------------------------------------------------------------------------------------"
+    Write-Host "---- Working on ip:" $hostPath
+    Write-Host "---------------------------------------------------------------------------------------------------------"
+
+    $manifestPath = $clusterDataRootPath + "\" + $hostPath + "\Fabric\ClusterManifest.current.xml"
+
+    $currentPackage = $clusterDataRootPath + "\" + $hostPath + "\Fabric\Fabric.Package.current.xml"
+    $infrastructureManifest = $clusterDataRootPath + "\" + $hostPath + "\Fabric\Fabric.Data\InfrastructureManifest.xml"
+
+    #to get the settings.xml we need to determine the current version
+    #"D:\SvcFab\_sys_0\Fabric\Fabric.Package.current.xml" --> Read to determine verion# <ConfigPackage Name="Fabric.Config" Version="1.131523081591497214" />
+    $currentPackageXml = [xml](Get-Content $currentPackage)
+    $packageName = $currentPackageXml.ServicePackage.DigestedConfigPackage.ConfigPackage | Select-Object -ExpandProperty Name
+    $packageVersion = $currentPackageXml.ServicePackage.DigestedConfigPackage.ConfigPackage | Select-Object -ExpandProperty Version
+    $SettingsFile = $clusterDataRootPath + "\" + $hostPath + "\Fabric\" + $packageName + "." + $packageVersion + "\settings.xml"
+    $SettingsPath = $clusterDataRootPath + "\" + $hostPath + "\Fabric\" + $packageName + "." + $packageVersion
+    Write-Host "$env:computername : settings file: " $SettingsFile
+    Write-Host "$env:computername : Settings path: " $SettingsPath
+
+    $settings = [xml](Get-Content $SettingsFile)
+
+    #TODO: validate newThumbprint is installed
+    $thumbprintPath = $certStoreLocation + $newThumbprint
+    If (!(Test-Path $thumbprintPath)) {
+        Write-Host "$env:computername : $newThumbprint not installed"
+        Exit-PSSession
+    }
+
+    #TODO: validate newThumbprint is ACL'd for NETWORK_SERVICE
+    #------------------------------------------------------- start ACL
+    #Change to the location of the local machine certificates
+    $currentLocation = Get-Location
+    Set-Location $certStoreLocation
+
+    #display list of installed certificates in this store
+    Get-ChildItem | Format-Table Subject, Thumbprint, SerialNumber -AutoSize
+    Set-Location $currentLocation
+
+    $thumbprint = $certStoreLocation + "\" + $newThumbprint
+    Write-Host "$env:computername : Setting ACL for $thumbprint" -ForegroundColor Green
+
+    #get the container name
+    $cert = get-item $thumbprint
+
+    # Specify the user, the permissions and the permission type
+    $permission = "$("NETWORK SERVICE")", "FullControl", "Allow"
+    $accessRule = New-Object -TypeName System.Security.AccessControl.FileSystemAccessRule -ArgumentList $permission
+
+    # Location of the machine related keys
+    $keyPath = Join-Path -Path $env:ProgramData -ChildPath "\Microsoft\Crypto\RSA\MachineKeys"
+    $keyName = $cert.PrivateKey.CspKeyContainerInfo.UniqueKeyContainerName
+    $keyFullPath = Join-Path -Path $keyPath -ChildPath $keyName
+
+    # Get the current acl of the private key
+    $acl = (Get-Item $keyFullPath).GetAccessControl('Access')
+
+    # Add the new ace to the acl of the private key
+    $acl.SetAccessRule($accessRule)
+
+    # Write back the new acl
+    Set-Acl -Path $keyFullPath -AclObject $acl -ErrorAction Stop
+
+    # Observe the access rights currently assigned to this certificate.
+    get-acl $keyFullPath | Format-List
+    #------------------------------------------------------- done ACL
+
+    # create a temp folder
+    New-Item -ItemType Directory -Force -Path 'd:\temp\certwork' | out-null
+
+    #copy current config to the temp folder
+    Copy-Item -Path $manifestPath -Destination 'd:\temp\certwork' -Force -Verbose
+    $newManifest = "D:\temp\certwork\modified_clustermanifest.xml"
+    Copy-Item -Path $infrastructureManifest -Destination 'd:\temp\certwork' -Force -Verbose
+    $newInfraManifest = "D:\temp\certwork\modified_InfrastructureManifest.xml"
+    Copy-Item -Path $SettingsFile -Destination 'd:\temp\certwork' -Force -Verbose
+    $newSettingsManifest = "D:\temp\certwork\modified_settings.xml"
+
+    # find and replace old thumbprint with the new one
+    (Get-Content "d:\temp\certwork\clustermanifest.current.xml" |
+        Foreach-Object { $_ -replace $oldThumbprint, $newThumbprint } |
+        Set-Content $newManifest)
+
+    # find and replace old thumbprint with the new one
+    (Get-Content "d:\temp\certwork\InfrastructureManifest.xml" |
+        Foreach-Object { $_ -replace $oldThumbprint, $newThumbprint } |
+        Set-Content $newInfraManifest)
+
+    # find and replace old thumbprint with the new one
+    (Get-Content "d:\temp\certwork\settings.xml" |
+        Foreach-Object { $_ -replace $oldThumbprint, $newThumbprint } |
+        Set-Content $newSettingsManifest)
+
+    $backupSettingsFile = $SettingsPath + "\settings_backup.xml"
+    Copy-Item -Path $SettingsFile -Destination $backupSettingsFile -Force -Verbose
+    Copy-Item -Path $newSettingsManifest -Destination $SettingsFile -Force -Verbose
+
+    #stop these services
+    Write-Host "$env:computername : Stopping services " -ForegroundColor Green
+    StopServiceFabricServices
+
+    #update the node configuration
+    $logRoot = $clusterDataRootPath + "\Log"
+    Write-Host "$env:computername : Updating Node configuration with new cert: $newThumbprint" -ForegroundColor Green
+    New-ServiceFabricNodeConfiguration -FabricDataRoot $clusterDataRootPath -FabricLogRoot $logRoot -ClusterManifestPath $newManifest -InfrastructureManifestPath $newInfraManifest
+    Write-Host "$env:computername : Updating Node configuration with new cert: complete" -ForegroundColor Green
+
+    #restart these services
+    Write-Host "$env:computername : Starting services " -ForegroundColor Green
+    StartServiceFabricServices
+}
+
+if ($localOnly) {
+    write-host "executing on local node only"
+    invoke-command -ScriptBlock $scriptBlock -ArgumentList $clusterDataRootPath, $oldThumbprint, $newThumbprint, $certStoreLocation
+    return
 }
 
 ForEach ($nodeIpAddress in $nodeIpArray) {
@@ -109,211 +319,8 @@ ForEach ($nodeIpAddress in $nodeIpArray) {
         }
 
         $error.clear()
-        Invoke-Command -Authentication Negotiate -Computername $nodeIpAddress -Scriptblock { param($clusterDataRootPath, $oldThumbprint, $newThumbprint, $certStoreLocation)
-            Write-Host "$env:computername : Running on $((Get-WmiObject win32_computersystem).DNSHostName)" -ForegroundColor Green
-
-            function StopServiceFabricServices {
-                if ($(Get-Process | ? ProcessName -like "*FabricInstaller*" | measure).Count -gt 0) {
-                    Write-Warning "$env:computername : Found FabricInstaller running, may cause issues if not stopped, consult manual guide..."
-                    Write-Host "$env:computername : Pausing (15s)..." -ForegroundColor Green
-                    Start-Sleep -Seconds 15
-                }
-
-                $bootstrapAgent = "ServiceFabricNodeBootstrapAgent"
-                $fabricHost = "FabricHostSvc"
-
-                $bootstrapService = Get-Service -Name $bootstrapAgent
-                if ($bootstrapService.Status -eq "Running") {
-                    Stop-Service $bootstrapAgent -ErrorAction SilentlyContinue 
-                    Write-Host "$env:computername : Stopping $bootstrapAgent service" -ForegroundColor Green
-                }
-                Do {
-                    Start-Sleep -Seconds 1
-                    $bootstrapService = Get-Service -Name $bootstrapAgent
-                    if ($bootstrapService.Status -eq "Stopped") {
-                        Write-Host "$env:computername : $bootstrapAgent now stopped" -ForegroundColor Green
-                    }
-                    else {
-                        Write-Host "$env:computername : $bootstrapAgent current status: $($bootstrapService.Status)" -ForegroundColor Green
-                    }
-
-                } While ($bootstrapService.Status -ne "Stopped")
-
-                $fabricHostService = Get-Service -Name $fabricHost
-                if ($fabricHostService.Status -eq "Running") {
-                    Stop-Service $fabricHost -ErrorAction SilentlyContinue 
-                    Write-Host "$env:computername : Stopping $fabricHost service" -ForegroundColor Green
-                }
-                Do {
-                    Start-Sleep -Seconds 1
-                    $fabricHostService = Get-Service -Name $fabricHost
-                    if ($fabricHostService.Status -eq "Stopped") {
-                        Write-Host "$env:computername : $fabricHost now stopped" -ForegroundColor Green
-                    }
-                    else {
-                        Write-Host "$env:computername : $fabricHost current status: $($fabricHostService.Status)" -ForegroundColor Green
-                    }
-
-                } While ($fabricHostService.Status -ne "Stopped")
-            }
-
-            function StartServiceFabricServices {
-                $bootstrapAgent = "ServiceFabricNodeBootstrapAgent"
-                $fabricHost = "FabricHostSvc"
-
-                $fabricHostService = Get-Service -Name $fabricHost
-                if ($fabricHostService.Status -eq "Stopped") {
-                    Start-Service $fabricHost -ErrorAction SilentlyContinue 
-                    Write-Host "$env:computername : Starting $fabricHost service" -ForegroundColor Green
-                }
-                Do {
-                    Start-Sleep -Seconds 1
-                    $fabricHostService = Get-Service -Name $fabricHost
-                    if ($fabricHostService.Status -eq "Running") {
-                        Write-Host "$env:computername : $fabricHost now running" -ForegroundColor Green
-                    }
-                    else {
-                        Write-Host "$env:computername : $fabricHost current status: $($fabricHostService.Status)" -ForegroundColor Green
-                    }
-
-                } While ($fabricHostService.Status -ne "Running")
-
-
-                $bootstrapService = Get-Service -Name $bootstrapAgent
-                if ($bootstrapService.Status -eq "Stopped") {
-                    Start-Service $bootstrapAgent -ErrorAction SilentlyContinue 
-                    Write-Host "$env:computername : Starting $bootstrapAgent service" -ForegroundColor Green
-                }
-                Do {
-                    Start-Sleep -Seconds 1
-                    $bootstrapService = Get-Service -Name $bootstrapAgent
-                    if ($bootstrapService.Status -eq "Running") {
-                        Write-Host "$env:computername : $bootstrapAgent now running" -ForegroundColor Green
-                    }
-                    else {
-                        Write-Host "$env:computername : $bootstrapAgent current status: $($bootstrapService.Status)" -ForegroundColor Green
-                    }
-
-                } While ($bootstrapService.Status -ne "Running")
-            }
-
-            #config files we need
-            #"D:\SvcFab\clusterManifest.xml"
-            #"D:\SvcFab\_sys_0\Fabric\Fabric.Data\InfrastructureManifest.xml"
-            #"D:\SvcFab\_sys_0\Fabric\Fabric.Config.1.131523081591497214\Settings.xml"
-
-            $result = Get-ChildItem -Path $clusterDataRootPath -Filter "Fabric.Data" -Directory -Recurse
-            $hostPath = $result.Parent.Parent.Name
-            Write-Host "---------------------------------------------------------------------------------------------------------"
-            Write-Host "---- Working on ip:" $hostPath
-            Write-Host "---------------------------------------------------------------------------------------------------------"
-
-            $manifestPath = $clusterDataRootPath + "\" + $hostPath + "\Fabric\ClusterManifest.current.xml"
-
-            $currentPackage = $clusterDataRootPath + "\" + $hostPath + "\Fabric\Fabric.Package.current.xml"
-            $infrastructureManifest = $clusterDataRootPath + "\" + $hostPath + "\Fabric\Fabric.Data\InfrastructureManifest.xml"
-
-            #to get the settings.xml we need to determine the current version
-            #"D:\SvcFab\_sys_0\Fabric\Fabric.Package.current.xml" --> Read to determine verion# <ConfigPackage Name="Fabric.Config" Version="1.131523081591497214" />
-            $currentPackageXml = [xml](Get-Content $currentPackage)
-            $packageName = $currentPackageXml.ServicePackage.DigestedConfigPackage.ConfigPackage | Select-Object -ExpandProperty Name
-            $packageVersion = $currentPackageXml.ServicePackage.DigestedConfigPackage.ConfigPackage | Select-Object -ExpandProperty Version
-            $SettingsFile = $clusterDataRootPath + "\" + $hostPath + "\Fabric\" + $packageName + "." + $packageVersion + "\settings.xml"
-            $SettingsPath = $clusterDataRootPath + "\" + $hostPath + "\Fabric\" + $packageName + "." + $packageVersion
-            Write-Host "$env:computername : settings file: " $SettingsFile
-            Write-Host "$env:computername : Settings path: " $SettingsPath
-
-            $settings = [xml](Get-Content $SettingsFile)
-
-            #TODO: validate newThumbprint is installed
-            $thumbprintPath = $certStoreLocation + $newThumbprint
-            If (!(Test-Path $thumbprintPath)) {
-                Write-Host "$env:computername : $newThumbprint not installed"
-                Exit-PSSession
-            }
-
-            #TODO: validate newThumbprint is ACL'd for NETWORK_SERVICE
-            #------------------------------------------------------- start ACL
-            #Change to the location of the local machine certificates
-            $currentLocation = Get-Location
-            Set-Location $certStoreLocation
-
-            #display list of installed certificates in this store
-            Get-ChildItem | Format-Table Subject, Thumbprint, SerialNumber -AutoSize
-            Set-Location $currentLocation
-
-            $thumbprint = $certStoreLocation + "\" + $newThumbprint
-            Write-Host "$env:computername : Setting ACL for $thumbprint" -ForegroundColor Green
-
-            #get the container name
-            $cert = get-item $thumbprint
-
-            # Specify the user, the permissions and the permission type
-            $permission = "$("NETWORK SERVICE")", "FullControl", "Allow"
-            $accessRule = New-Object -TypeName System.Security.AccessControl.FileSystemAccessRule -ArgumentList $permission
-
-            # Location of the machine related keys
-            $keyPath = Join-Path -Path $env:ProgramData -ChildPath "\Microsoft\Crypto\RSA\MachineKeys"
-            $keyName = $cert.PrivateKey.CspKeyContainerInfo.UniqueKeyContainerName
-            $keyFullPath = Join-Path -Path $keyPath -ChildPath $keyName
-
-            # Get the current acl of the private key
-            $acl = (Get-Item $keyFullPath).GetAccessControl('Access')
-
-            # Add the new ace to the acl of the private key
-            $acl.SetAccessRule($accessRule)
-
-            # Write back the new acl
-            Set-Acl -Path $keyFullPath -AclObject $acl -ErrorAction Stop
-
-            # Observe the access rights currently assigned to this certificate.
-            get-acl $keyFullPath | Format-List
-            #------------------------------------------------------- done ACL
-
-            # create a temp folder
-            New-Item -ItemType Directory -Force -Path 'd:\temp\certwork' | out-null
-
-            #copy current config to the temp folder
-            Copy-Item -Path $manifestPath -Destination 'd:\temp\certwork' -Force -Verbose
-            $newManifest = "D:\temp\certwork\modified_clustermanifest.xml"
-            Copy-Item -Path $infrastructureManifest -Destination 'd:\temp\certwork' -Force -Verbose
-            $newInfraManifest = "D:\temp\certwork\modified_InfrastructureManifest.xml"
-            Copy-Item -Path $SettingsFile -Destination 'd:\temp\certwork' -Force -Verbose
-            $newSettingsManifest = "D:\temp\certwork\modified_settings.xml"
-
-            # find and replace old thumbprint with the new one
-            (Get-Content "d:\temp\certwork\clustermanifest.current.xml" |
-                Foreach-Object { $_ -replace $oldThumbprint, $newThumbprint } |
-                Set-Content $newManifest)
-
-            # find and replace old thumbprint with the new one
-            (Get-Content "d:\temp\certwork\InfrastructureManifest.xml" |
-                Foreach-Object { $_ -replace $oldThumbprint, $newThumbprint } |
-                Set-Content $newInfraManifest)
-
-            # find and replace old thumbprint with the new one
-            (Get-Content "d:\temp\certwork\settings.xml" |
-                Foreach-Object { $_ -replace $oldThumbprint, $newThumbprint } |
-                Set-Content $newSettingsManifest)
-
-            $backupSettingsFile = $SettingsPath + "\settings_backup.xml"
-            Copy-Item -Path $SettingsFile -Destination $backupSettingsFile -Force -Verbose
-            Copy-Item -Path $newSettingsManifest -Destination $SettingsFile -Force -Verbose
-
-            #stop these services
-            Write-Host "$env:computername : Stopping services " -ForegroundColor Green
-            StopServiceFabricServices
-
-            #update the node configuration
-            $logRoot = $clusterDataRootPath + "\Log"
-            Write-Host "$env:computername : Updating Node configuration with new cert: $newThumbprint" -ForegroundColor Green
-            New-ServiceFabricNodeConfiguration -FabricDataRoot $clusterDataRootPath -FabricLogRoot $logRoot -ClusterManifestPath $newManifest -InfrastructureManifestPath $newInfraManifest
-            Write-Host "$env:computername : Updating Node configuration with new cert: complete" -ForegroundColor Green
-
-            #restart these services
-            Write-Host "$env:computername : Starting services " -ForegroundColor Green
-            StartServiceFabricServices
-        } -ArgumentList $clusterDataRootPath, $oldThumbprint, $newThumbprint, $certStoreLocation
+        Invoke-Command -Authentication Negotiate -Computername $nodeIpAddress -Scriptblock $scriptBlock `
+            -ArgumentList $clusterDataRootPath, $oldThumbprint, $newThumbprint, $certStoreLocation
         
         if ($error) {
             $global:failNodes += $nodeIpAddress
@@ -342,6 +349,7 @@ if ($global:failNodes) {
     $failUnique = $global:failNodes | sort-object -Unique
     write-warning "`r`ntotal node connection errors: $(@($failUnique).Count). review output"   
     write-host ($failUnique | fl * | out-string)
+    write-warning "for any failed nodes, rdp to node and run this script with '-localOnly' switch"
 }
 
 write-host "finished. total minutes: $(((get-date) - $startTime).TotalMinutes.ToString("0.0"))" -foregroundcolor green

--- a/Scripts/FixExpiredCert.ps1
+++ b/Scripts/FixExpiredCert.ps1
@@ -64,8 +64,12 @@ If (!(Test-Path $clusterDataRootPath)) {
 $curValue = (get-item wsman:\localhost\Client\TrustedHosts).value
 
 if (![regex]::IsMatch($oldThumbprint, '^[0-9A-Fa-f]{24,}$') -or ![regex]::IsMatch($newThumbprint, '^[0-9A-Fa-f]{24,}$')) {
-    write-warning "verify oldthumbprint:($oldthumbprint) and newthumbprint:($newthumbprint) are specified and are correct."
-    #return
+    $errMessage = "verify oldthumbprint:($oldthumbprint) and newthumbprint:($newthumbprint) are specified and are correct."
+    if($oldThumbprint.Contains(' ') -or $oldThumbprint.Contains(' ')){
+        write-error $errMessage
+        return
+    }
+    write-warning $errMessage
 }
 
 $scriptBlock = { param($clusterDataRootPath, $oldThumbprint, $newThumbprint, $certStoreLocation)
@@ -188,7 +192,7 @@ $scriptBlock = { param($clusterDataRootPath, $oldThumbprint, $newThumbprint, $ce
     $thumbprintPath = $certStoreLocation + $newThumbprint
     If (!(Test-Path $thumbprintPath)) {
         Write-Host "$env:computername : $newThumbprint not installed"
-        Exit-PSSession
+        return
     }
 
     #TODO: validate newThumbprint is ACL'd for NETWORK_SERVICE
@@ -201,7 +205,7 @@ $scriptBlock = { param($clusterDataRootPath, $oldThumbprint, $newThumbprint, $ce
     Get-ChildItem | Format-Table Subject, Thumbprint, SerialNumber -AutoSize
     Set-Location $currentLocation
 
-    $thumbprint = $certStoreLocation + "\" + $newThumbprint
+    $thumbprint = $certStoreLocation + $newThumbprint
     Write-Host "$env:computername : Setting ACL for $thumbprint" -ForegroundColor Green
 
     #get the container name

--- a/Scripts/FixExpiredCert.ps1
+++ b/Scripts/FixExpiredCert.ps1
@@ -63,17 +63,6 @@ If (!(Test-Path $clusterDataRootPath)) {
 
 $curValue = (get-item wsman:\localhost\Client\TrustedHosts).value
 
-if (!$global:creds) {
-    Write-Host "Enter your RDP Credentials"
-
-    #Get the RDP User Name and Password
-    $creds = Get-Credential
-
-    if ($cacheCredentials) {
-        $global:creds = $creds
-    }
-}
-
 if (![regex]::IsMatch($oldThumbprint, '^[0-9A-Fa-f]{24,}$') -or ![regex]::IsMatch($newThumbprint, '^[0-9A-Fa-f]{24,}$')) {
     write-warning "verify oldthumbprint:($oldthumbprint) and newthumbprint:($newthumbprint) are specified and are correct."
     #return
@@ -289,6 +278,17 @@ if ($localOnly) {
     write-host "executing on local node only"
     invoke-command -ScriptBlock $scriptBlock -ArgumentList $clusterDataRootPath, $oldThumbprint, $newThumbprint, $certStoreLocation
     return
+}
+
+if (!$global:creds) {
+    Write-Host "Enter your RDP Credentials"
+
+    #Get the RDP User Name and Password
+    $creds = Get-Credential
+
+    if ($cacheCredentials) {
+        $global:creds = $creds
+    }
 }
 
 ForEach ($nodeIpAddress in $nodeIpArray) {


### PR DESCRIPTION
Scripts/FixExpiredCert-AEPCC.ps1
Scripts/FixExpiredCert.ps1

add -localOnly switch to be used when there are issues connecting to nodes over network
add Scripts/FixExpiredCert-AEPCC.ps1 default values if registry key is not there 
modify Scripts/FixExpiredCert.ps1 to fail if spaces in $currentThumbprint or $newThumbprint

diffs look big because 'scriptBody' is now at root level so it can be used outside and inside the network loop
'scriptBody' functions were *not* modified

tested:
- with and without registry 
- with and without -localOnly