### PR TITLE
Mirantis scriptv2 adding mutex to prevent sf extension starting before restart

### DIFF
--- a/Deployment/Mirantis-Installation.md
+++ b/Deployment/Mirantis-Installation.md
@@ -60,6 +60,53 @@ The Custom Script VM Extension to install Mirantis must run before Service Fabri
                     "type": "ServiceFabricNode",
 ```
 
+## Troubleshooting
+
+If using [Install-Mirantis.ps1](https://raw.githubusercontent.com/Azure/Service-Fabric-Troubleshooting-Guides/master/Scripts/Install-Mirantis.ps1) to install Mirantis with default of 'registerEvent' set to true, an event be logged to the 'Application' event log. The script will write the powershell transcript of the installation using 'Source' of 'CustomScriptExtension' by default.
+
+There are also status and log files in multiple locations on the local c: drive of the virtual machine.
+
+### File locations
+
+#### **Extension status**
+
+The x.status file(s) are a json files containing the status of the Custom Script Extension and execution of install-mirantis script output.
+
+- C:\Packages\Plugins\Microsoft.Compute.CustomScriptExtension\\<version\>\Status\\<version\>.status
+    - Example: C:\Packages\Plugins\Microsoft.Compute.CustomScriptExtension\1.10.15\Status\1.status
+
+#### **File downloads**
+
+File downloads will have the install-mirantis script file if download was successful. In addition, if installation started, the powershell transcript.log will be written to this location.
+
+- C:\Packages\Plugins\Microsoft.Compute.CustomScriptExtension\\<version\>\Downloads\\<version\>
+
+    ```text
+    C:\PACKAGES\PLUGINS\MICROSOFT.COMPUTE.CUSTOMSCRIPTEXTENSION\1.10.15\DOWNLOADS
+    └───1
+            install-mirantis.ps1
+            install.ps1
+            install.ps1.oem
+            transcript.log
+    ```
+
+#### **Extension log archive**
+
+Contains output similar to above locations but also contains history of previous executions with additional extension logging.
+
+- C:\WindowsAzure\Logs\Plugins\Microsoft.Compute.CustomScriptExtension\\<version\>
+
+    ```text
+    C:\WINDOWSAZURE\LOGS\PLUGINS\MICROSOFT.COMPUTE.CUSTOMSCRIPTEXTENSION
+    └───1.10.15
+        CommandExecution.log
+        CommandExecution_20230416135036514.log
+        CommandExecution_20230416135328172.log
+        CommandExecution_20230416135720159.log
+        CommandExecution_20230416135905790.log
+        CustomScriptHandler.log
+    ```
+
 ## Documentation
 
 - [Custom Script Extension for Windows](https://docs.microsoft.com/azure/virtual-machines/extensions/custom-script-windows)

--- a/Deployment/Mirantis-Installation.md
+++ b/Deployment/Mirantis-Installation.md
@@ -14,7 +14,13 @@ The recommended way to add a virtual machine scale set extension on an Azure Ser
 
 The PowerShell script is prepared to check if Mirantis needs to be installed by downloading and executing the Mirantis installer, after successful installation the machine will be restarted.
 
-Please use a copy of [Install-Mirantis.ps1](https://raw.githubusercontent.com/Azure/Service-Fabric-Troubleshooting-Guides/master/Scripts/Install-Mirantis.ps1) to install Mirantis Container Runtime on your Azure Service Fabric cluster.
+Please use a copy of [Install-Mirantis.ps1](https://raw.githubusercontent.com/Azure/Service-Fabric-Troubleshooting-Guides/master/Scripts/Install-Mirantis.ps1) to install Mirantis Container Runtime on your Azure Service Fabric cluster. If your Service Fabric project is hyper-v isolated container based, add script switch '-hypervIsolation' to the 'commandToExecute' variable.
+
+Example:
+
+```json
+    "commandToExecute": "powershell -ExecutionPolicy Unrestricted -File .\\Install-Mirantis.ps1 -hypervIsolation"
+```
 
 > [!NOTE] It is highly recommended to save scripts somewhere in your own storage to be protected to changes from external sources. In this way your production environment will not face untested scenarios. Please use a copy of the scripts provided as any change should be tested first before going into production.
 
@@ -33,7 +39,7 @@ Please use a copy of [Install-Mirantis.ps1](https://raw.githubusercontent.com/Az
                         "fileUris": [
                             "https://raw.githubusercontent.com/Azure/Service-Fabric-Troubleshooting-Guides/master/Scripts/Install-Mirantis.ps1"
                         ],
-                        "commandToExecute": "[concat('powershell -ExecutionPolicy Unrestricted -File .\\', 'Mirantis-Install.ps1')]"
+                        "commandToExecute": "powershell -ExecutionPolicy Unrestricted -File .\\Install-Mirantis.ps1"
                     }
                     }
                 }

--- a/Deployment/Mirantis-Installation.md
+++ b/Deployment/Mirantis-Installation.md
@@ -14,7 +14,7 @@ The recommended way to add a virtual machine scale set extension on an Azure Ser
 
 The PowerShell script is prepared to check if Mirantis needs to be installed by downloading and executing the Mirantis installer, after successful installation the machine will be restarted.
 
-Please use a copy of [Install-Mirantis.ps1](https://raw.githubusercontent.com/Azure/Service-Fabric-Troubleshooting-Guides/master/Scripts/Install-Mirantis.ps1) to install Mirantis Container Runtime on your Azure Service Fabric cluster. If your Service Fabric project is hyper-v isolated container based, please also use a copy of [Install-Mirantis-with-HyperV.ps1](https://raw.githubusercontent.com/Azure/Service-Fabric-Troubleshooting-Guides/master/Scripts/Install-Mirantis-with-HyperV.ps1) and [Enable-HyperV.ps1](https://raw.githubusercontent.com/Azure/Service-Fabric-Troubleshooting-Guides/master/Scripts/Enable-HyperV.ps1) to enable the Hyper-V as well.
+Please use a copy of [Install-Mirantis.ps1](https://raw.githubusercontent.com/Azure/Service-Fabric-Troubleshooting-Guides/master/Scripts/Install-Mirantis.ps1) to install Mirantis Container Runtime on your Azure Service Fabric cluster.
 
 > [!NOTE] It is highly recommended to save scripts somewhere in your own storage to be protected to changes from external sources. In this way your production environment will not face untested scenarios. Please use a copy of the scripts provided as any change should be tested first before going into production.
 
@@ -31,11 +31,9 @@ Please use a copy of [Install-Mirantis.ps1](https://raw.githubusercontent.com/Az
                     "autoUpgradeMinorVersion": true,
                     "settings": {
                         "fileUris": [
-                            "https://raw.githubusercontent.com/Azure/Service-Fabric-Troubleshooting-Guides/master/Scripts/Enable-HyperV.ps1", 
-                            "https://raw.githubusercontent.com/Azure/Service-Fabric-Troubleshooting-Guides/master/Scripts/Install-Mirantis-with-HyperV.ps1", 
-                            "https://raw.githubusercontent.com/Azure/Service-Fabric-Troubleshooting-Guides/master/Scripts/Install-Mirantis.ps1" 
+                            "https://raw.githubusercontent.com/Azure/Service-Fabric-Troubleshooting-Guides/master/Scripts/Install-Mirantis.ps1"
                         ],
-                        "commandToExecute": "[concat('powershell -ExecutionPolicy Unrestricted -File .\\', 'Install-Mirantis-with-HyperV.ps1')]"
+                        "commandToExecute": "[concat('powershell -ExecutionPolicy Unrestricted -File .\\', 'Mirantis-Install.ps1')]"
                     }
                     }
                 }

--- a/Scripts/Enable-HyperV.ps1
+++ b/Scripts/Enable-HyperV.ps1
@@ -1,2 +1,0 @@
-Install-WindowsFeature -Name Hyper-V -IncludeAllSubFeature -IncludeManagementTools
-Restart-Computer -Force

--- a/Scripts/Install-Mirantis-with-HyperV.ps1
+++ b/Scripts/Install-Mirantis-with-HyperV.ps1
@@ -1,2 +1,0 @@
-.\Install-Mirantis.ps1
-.\Enable-HyperV.ps1


### PR DESCRIPTION
- Mirantis scriptv2 adding mutex to prevent sf extension starting before restart
-- intermittent timing issue seen on 2022 with small sku
Status Message: VM has reported a failure when processing    
     | extension 'nt0_ServiceFabricNode'. Error message: "Enable Failed. Exception System.IO.IOException: The media is write protected.     at
     | Microsoft.Win32.RegistryKey.Win32Error(Int32 errorCode, String str)    at Microsoft.Win32.RegistryKey.CreateSubKeyInternal(String subkey,

- reverting last change to markdown as functionality is already in script
- updated markdown with existing -hypervIsolation
- add troubleshooting steps to markdown