### PR TITLE
fix for github action error: Error [ERR_UNKNOWN_BUILTIN_MODULE]: No such built-in module: node:assert/strict npm install --global remark-cli remark-validate-links

### DIFF
--- a/.github/workflows/deadlinkcheck.yml
+++ b/.github/workflows/deadlinkcheck.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [20.x]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
fix for github action error: Error [ERR_UNKNOWN_BUILTIN_MODULE]: No such built-in module: node:assert/strict npm install --global remark-cli remark-validate-links

  shell: /usr/bin/bash -e {0}
/opt/hostedtoolcache/node/14.21.3/x64/bin/remark -> /opt/hostedtoolcache/node/14.21.3/x64/lib/node_modules/remark-cli/cli.js npm WARN notsup Unsupported engine for markdown-extensions@2.0.0: wanted: {"node":">=16"} (current: {"node":"14.21.3","npm":"6.14.18"}) n