### PR TITLE
modifying managed cluster auto os image upgrade documentation now that it supports/uses standard vmss functionality and cmdlets

### DIFF
--- a/Deployment/How to Configure Service Fabric Cluster Automatic OS Image Upgrade.md
+++ b/Deployment/How to Configure Service Fabric Cluster Automatic OS Image Upgrade.md
@@ -241,8 +241,6 @@ Azure Service Fabric clusters support [Maintenance Control](https://learn.micros
 > **Note**
 > Maintenance Control requires a schedule with minimum settings of daily schedule with at least a 5 hour window. Updates not completed in the provided window will resume during next window.
 
-Azure Service Fabric Managed Clusters support for Maintenance Control is currently in preview. See [MaintenanceControl](https://learn.microsoft.com/azure/service-fabric/how-to-managed-cluster-maintenance-control) for configuration and support information as not all regions are currently supported.
-
 ### Enumerate current OS image SKU's available in Azure
 
 New images are applied based on policy settings. [enumerate-vmss-image-sku.ps1](../Scripts/enumerate-vmss-image-sku.ps1) enumerates current OS image SKU's available in Azure to verify if node type is running the latest OS image version.


### PR DESCRIPTION
modifying managed cluster auto os image upgrade documentation now that it supports/uses standard vmss functionality and cmdlets